### PR TITLE
Added better shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Setting the kernel parameter depends on what bootloader you are using. Complete 
    - The edited line should look something like this: **Target=nvidia-470xx-dkms**
 5. Save the file with _CTRL+S_ and close nano with _CTRL+X_
 6. Move the file to **/etc/pacman.d/hooks/** with: `sudo mv ./nvidia.hook /etc/pacman.d/hooks/`
-
+note: make hooks directory if needed.
 ## Step 4: Reboot and enjoy!
 
 You can now safely reboot and enjoy the proprietary NVIDIA drivers. If you have any problems check the Arch Linux Wiki or the forums for common pitfalls and questions.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Setting the kernel parameter depends on what bootloader you are using. Complete 
 4. Replace the word **nvidia** with the base driver you installed, e.g., **nvidia-470xx-dkms**
    - The edited line should look something like this: **Target=nvidia-470xx-dkms**
 5. Save the file with _CTRL+S_ and close nano with _CTRL+X_
-6. Move the file to **/etc/pacman.d/hooks/** with: `sudo mv ./nvidia.hook /etc/pacman.d/hooks/`
-note: make hooks directory if needed.
+6. Move the file to **/etc/pacman.d/hooks/** with: `sudo mkdir -p /etc/pacman.d/hooks/ && sudo mv ./nvidia.hook /etc/pacman.d/hooks/`
+
 ## Step 4: Reboot and enjoy!
 
 You can now safely reboot and enjoy the proprietary NVIDIA drivers. If you have any problems check the Arch Linux Wiki or the forums for common pitfalls and questions.


### PR DESCRIPTION
Step 3.6: 
Added `mkdir -p /etc/pacman.d/hooks/` in case there is no `/etc/pacman.d/hooks/` directory exists which is the default case in most cases.